### PR TITLE
Don't prepend 're: ' to CW on self-replies

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -315,7 +315,7 @@ export default function compose(state = initialState, action) {
 
       if (action.status.get('spoiler_text').length > 0) {
         let spoiler_text = action.status.get('spoiler_text');
-        if (!spoiler_text.match(/^re[: ]/i)) {
+        if (!spoiler_text.match(/^re[: ]/i) && action.status.getIn(['account', 'id']) !== me) {
           spoiler_text = 're: '.concat(spoiler_text);
         }
         map.set('spoiler', true);


### PR DESCRIPTION
here's hoping this doesn't break the whole thing